### PR TITLE
Use WebUI port from ENV variable for qbittorrent process

### DIFF
--- a/root/etc/services.d/qbittorrent/run
+++ b/root/etc/services.d/qbittorrent/run
@@ -3,4 +3,4 @@
 
 umask "${UMASK}"
 
-exec s6-setuidgid hotio /usr/bin/qbittorrent-nox --profile="${APP_DIR}" --webui-port=8080
+exec s6-setuidgid hotio /usr/bin/qbittorrent-nox --profile="${APP_DIR}" --webui-port="${WEBUI_PORTS%%/*}"


### PR DESCRIPTION
Use the ENV variable `WEBUI_PORTS` for the qbittorrent main process to be able to set the WebUI port manually 