### PR TITLE
fix: non latest version matching

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -29,7 +29,7 @@ elif [[ ${1} == "screenshot" ]]; then
 else
     vuetorrent_version=$(curl -u "${GITHUB_ACTOR}:${GITHUB_TOKEN}" -fsSL "https://api.github.com/repos/wdaan/vuetorrent/releases/latest" | jq -r .tag_name | sed s/v//g)
     [[ -z ${vuetorrent_version} ]] && exit 1
-    qbts_latest_release="$(curl -sL https://github.com/userdocs/qbittorrent-nox-static/releases/latest/download/dependency-version.json | jq -r '.qbittorrent')"
+    qbts_latest_release="$(curl -fsSL https://github.com/userdocs/qbittorrent-nox-static/releases/latest/download/dependency-version.json | jq -r '.qbittorrent')"
     full_version="$(curl -u "${GITHUB_ACTOR}:${GITHUB_TOKEN}" -fsSL "https://api.github.com/repos/userdocs/qbittorrent-nox-static/releases" | jq -r 'first(.[] | select(.tag_name | contains ("release-'"${qbts_latest_release}"_v1.2.'")) | .tag_name)')"
     version=$(echo "${full_version}" | sed -e "s/release-//g" -e "s/_.*//g")
     [[ -z ${version} ]] && exit 1

--- a/update.sh
+++ b/update.sh
@@ -30,7 +30,7 @@ else
     vuetorrent_version=$(curl -u "${GITHUB_ACTOR}:${GITHUB_TOKEN}" -fsSL "https://api.github.com/repos/wdaan/vuetorrent/releases/latest" | jq -r .tag_name | sed s/v//g)
     [[ -z ${vuetorrent_version} ]] && exit 1
     qbts_latest_release="$(curl -fsSL https://github.com/userdocs/qbittorrent-nox-static/releases/latest/download/dependency-version.json | jq -r '.qbittorrent')"
-    full_version="$(curl -u "${GITHUB_ACTOR}:${GITHUB_TOKEN}" -fsSL "https://api.github.com/repos/userdocs/qbittorrent-nox-static/releases" | jq -r 'first(.[] | select(.tag_name | contains ("release-'"${qbts_latest_release}"_v1.2.'")) | .tag_name)')"
+    full_version="$(curl -u "${GITHUB_ACTOR}:${GITHUB_TOKEN}" -fsSL "https://api.github.com/repos/userdocs/qbittorrent-nox-static/releases" | jq -r 'first(.[] | select(.tag_name | contains ("release-'"${qbts_latest_release}"'_v1.2.")) | .tag_name)')"
     version=$(echo "${full_version}" | sed -e "s/release-//g" -e "s/_.*//g")
     [[ -z ${version} ]] && exit 1
     old_version=$(jq -r '.version' < VERSION.json)

--- a/update.sh
+++ b/update.sh
@@ -29,7 +29,8 @@ elif [[ ${1} == "screenshot" ]]; then
 else
     vuetorrent_version=$(curl -u "${GITHUB_ACTOR}:${GITHUB_TOKEN}" -fsSL "https://api.github.com/repos/wdaan/vuetorrent/releases/latest" | jq -r .tag_name | sed s/v//g)
     [[ -z ${vuetorrent_version} ]] && exit 1
-    full_version=$(curl -u "${GITHUB_ACTOR}:${GITHUB_TOKEN}" -fsSL "https://api.github.com/repos/userdocs/qbittorrent-nox-static/releases" | jq -r '[.[] | select(.prerelease==true)][0] | .tag_name')
+    qbts_latest_release="$(curl -sL https://github.com/userdocs/qbittorrent-nox-static/releases/latest/download/dependency-version.json | jq -r '.qbittorrent')"
+    full_version="$(curl -u "${GITHUB_ACTOR}:${GITHUB_TOKEN}" -fsSL "https://api.github.com/repos/userdocs/qbittorrent-nox-static/releases" | jq -r 'first(.[] | select(.tag_name | contains ("release-'"${qbts_latest_release}"_v1.2.'")) | .tag_name)')"
     version=$(echo "${full_version}" | sed -e "s/release-//g" -e "s/_.*//g")
     [[ -z ${version} ]] && exit 1
     old_version=$(jq -r '.version' < VERSION.json)


### PR DESCRIPTION
**Problem:** When using an index value to assume the position of the pre release release we want, we may get a wrong version, as happened when I built a custom version of 4.3.9 as a pre-release after the normal build process. This led to `release-4.4.3.1_v1.2.17` being downgraded to `release-4.3.9_v1.2.17` at the index position `[0]` of the pre re was replaced by this new pre release.

**Solution:** My releases provide a `dependency-version.json` as a released file which can cleanly let us know the specific version of qbittorrent on the latest release without any fancy or complicated checks. So we can quickly determine the release value we need to know to determine which pre release we want. So we set this to a variable like this

```bash
qbts_latest_release="$(curl -sL https://github.com/userdocs/qbittorrent-nox-static/releases/latest/download/dependency-version.json | jq -r '.qbittorrent')"
```

Using this version variable we can be more specific with `jq` about what we are looking for by returning the first result of a targeted search/filter value instead of looking at the index position `[0]`

```jq
jq -r 'first(.[] | select(.tag_name | contains ("release-'"${qbts_latest_release}"_v1.2.'")) | .tag_name)'
```

If we don't filter the first result and see them all we get this, for example.

```jq
jq -r '.[] | select(.tag_name | contains ("release-'"${qbts_latest_release}"_v1.2.'")) |
.tag_name'
release-4.4.3.1_v1.2.17
release-4.4.3.1_v1.2.16
```

I think this is a better approach to determining the release value we want as it will ignore index value shifts and always produce a more targeted and relevant result.

It worked in my testing but I have not tested the build process itself so it needs double checking to make sure it solves the problem.